### PR TITLE
Fix: warning 'connect deprecated res.headerSent: use standard res.hea…

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (req, res, next) {
           , new Error().stack.split("\n")[l].trim()
           , type
         ]);
-        if (!res.headerSent) res.set("X-ChromeLogger-Data", encode(data));
+        if (!res.headersSent) res.set("X-ChromeLogger-Data", encode(data));
       } catch (e) {
         data.rows.pop();
         log("error", 3)(e.toString());


### PR DESCRIPTION
…dersSent at node_modules/express-chrome-logger/index.js:29:17'

res.headerSent is [deprecated](https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x#resheadersent) in express v 4,
also [res.header**s**Sent](https://nodejs.org/docs/latest-v0.10.x/api/http.html#http_response_headerssent) is a standard in Node since I think the very beginning of the node project.

Thanks for very good middleware :)
